### PR TITLE
Add Railway deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Read more on each platform in our [docs](https://wasp.sh/docs/deployment/deploym
 
 - `railway-token` (required for Railway): Railway API token
 - `project-name` (required for Railway): Project name, max 25 characters
-- `railway-workspace-id` (optional): Railway workspace ID for multi-workspace accounts
 
 ## Github Action Secrets
 
@@ -63,9 +62,8 @@ jobs:
 ### Requirements
 
 - Prerequisites: Run `wasp deploy railway launch <project-name>` locally first
-- Add Github secrets as below:
+- Add Github secrets:
   - Get a Railway **project token** and add it as repository secret called `RAILWAY_TOKEN`
-  - Add Railway workspace ID as repository secret called `RAILWAY_WORKSPACE_ID` (optional, needed for multi-workspace accounts)
 
 ### Example
 
@@ -87,7 +85,6 @@ jobs:
           platform: railway
           railway-token: ${{ secrets.RAILWAY_TOKEN }}
           project-name: my-app # Required, max 25 characters
-          railway-workspace-id: ${{ secrets.RAILWAY_WORKSPACE_ID }} # Optional
           server-url: ${{ secrets.SERVER_URL }} # Optional
           wasp-version: "0.18.0" # Optional
 ```

--- a/README.md
+++ b/README.md
@@ -1,20 +1,40 @@
 # deploy-action 🚀
 
-<!-- TODO: Update intro to mention both Fly.io and Railway support -->
+Github Action to deploy Wasp apps to Fly.io or Railway.
 
-<!-- TODO: Add platform comparison table showing key differences between Fly.io and Railway -->
+Read more on each platform in our [docs](https://wasp.sh/docs/deployment/deployment-methods/wasp-deploy/overview).
+
+## Action Inputs
+
+### General
+
+- `platform` (required): 'fly' or 'railway'
+- `server-url` (optional): If you have configured a custom domain for your server, provide its URL here. If this is not defined, Wasp will default to using the deployment URL provided by the platform.
+- `wasp-version` (optional): Specific Wasp version to use, defaults to latest
+
+### Fly.io Specific
+
+- `fly-token` (required for Fly): Fly.io API token
+
+### Railway Specific
+
+- `railway-token` (required for Railway): Railway API token
+- `project-name` (required for Railway): Project name, max 25 characters
+- `railway-workspace-id` (optional): Railway workspace ID for multi-workspace accounts
+
+## Github Action Secrets
+
+For detailed instructions on setting up repository secrets, visit: [GitHub Docs: Creating Encrypted Secrets for a Repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 
 ## Deploying to Fly.io
 
-<!-- TODO: Explain Fly.io setup:
 - Prerequisites: Run `wasp deploy fly launch <basename> <region>` locally first
 - Commit the generated `fly-server.toml` and `fly-client.toml` files to repository
 - Get Fly.io API token from https://fly.io/user/personal_access_tokens
-- Add token as repository secret called FLY_TOKEN
-- Link to GitHub docs on creating secrets
--->
+- Add token as repository secret called `FLY_TOKEN`
 
-<!-- TODO: Show example workflow for Fly.io deployment:
+### Example
+
 ```yml
 name: Deploy to Fly.io
 
@@ -32,24 +52,23 @@ jobs:
         with:
           platform: fly
           fly-token: ${{ secrets.FLY_TOKEN }}
-          server-url: ${{ secrets.SERVER_URL }}  # Optional
-          wasp-version: "0.16.0"                 # Optional
+          server-url: ${{ secrets.SERVER_URL }} # Optional
+          wasp-version: "0.18.0" # Optional
 ```
--->
 
 ## Deploying to Railway
 
-<!-- TODO: Explain Railway setup:
 - Prerequisites: Run `wasp deploy railway launch <project-name>` locally first
 - No configuration files to commit (Railway stores config on platform)
 - Project name MUST be max 25 characters
-- Get Railway token from Project Settings → Tokens (project token recommended)
-- Add token as repository secret called RAILWAY_TOKEN
-- Optional: Workspace ID for multi-workspace accounts
-- Link to GitHub docs on creating secrets
--->
+- Get a Railway **project token**
+- Add token as repository secret called `RAILWAY_TOKEN`
+- Add Railway workspace ID as repository secret called `RAILWAY_WORKSPACE_ID` (optional, needed for multi-workspace accounts)
 
-<!-- TODO: Show example workflow for Railway deployment:
+### Getting the Railway Token
+
+### Example
+
 ```yml
 name: Deploy to Railway
 
@@ -67,29 +86,8 @@ jobs:
         with:
           platform: railway
           railway-token: ${{ secrets.RAILWAY_TOKEN }}
-          project-name: my-app                       # Required (max 25 chars)
-          railway-workspace: ${{ secrets.RAILWAY_WORKSPACE }}  # Optional
-          server-url: ${{ secrets.SERVER_URL }}      # Optional
-          wasp-version: "0.16.0"                     # Optional
+          project-name: my-app # Required, max 25 characters
+          railway-workspace-id: ${{ secrets.RAILWAY_WORKSPACE_ID }} # Optional
+          server-url: ${{ secrets.SERVER_URL }} # Optional
+          wasp-version: "0.18.0" # Optional
 ```
--->
-
-## Action Inputs
-
-<!-- TODO: Document all inputs:
-- platform (required): 'fly' or 'railway'
-- fly-token (required for fly): Fly.io API token
-- railway-token (required for railway): Railway API token
-- project-name (required for railway): Project name, max 25 characters
-- railway-workspace (optional): Railway workspace ID for multi-workspace accounts
-- server-url (optional): Custom server URL for the React app
-- wasp-version (optional): Specific Wasp version to use, defaults to latest
--->
-
-## Breaking Changes
-
-<!-- TODO: Add breaking change notice:
-- Existing users MUST add `platform: fly` to their workflow to continue working
-- The `fly-token` input is no longer required by default (only when platform is 'fly')
-- Show before/after example
--->

--- a/README.md
+++ b/README.md
@@ -1,45 +1,28 @@
 # deploy-action 🚀
 
-Github Action to deploy with Wasp to Fly.io
+<!-- TODO: Update intro to mention both Fly.io and Railway support -->
 
-## How to setup Deploy on Push
+<!-- TODO: Add platform comparison table showing key differences between Fly.io and Railway -->
 
-### Launch your app locally once ⚠️
+## Deploying to Fly.io
 
-- You should first launch your app locally with `wasp deploy fly launch <basename> <region>`.
-- After your app is launched, make sure to commit the `fly-server.toml` and `fly-client.toml` files.
+<!-- TODO: Explain Fly.io setup:
+- Prerequisites: Run `wasp deploy fly launch <basename> <region>` locally first
+- Commit the generated `fly-server.toml` and `fly-client.toml` files to repository
+- Get Fly.io API token from https://fly.io/user/personal_access_tokens
+- Add token as repository secret called FLY_TOKEN
+- Link to GitHub docs on creating secrets
+-->
 
-### Action Inputs
-
-#### Get your API token from Fly.io
-
-- Login with Fly.io and go here: https://fly.io/user/personal_access_tokens
-- Click `Create token` and copy that value.
-- Add your Fly.io token as a repository secret e.g. calling it `FLY_TOKEN`
-
-  Read more about how to do it: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
-
-#### Setting a Custom Server URL
-
-If you have configured a custom domain for your server, you can specify it as a repository secret named `SERVER_URL`. If this is not defined, Wasp will default to using the `<app-name>-server.fly.dev` address.
-
-For detailed instructions on setting up repository secrets, visit: [GitHub Docs: Creating Encrypted Secrets for a Repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
-
-#### Setting a Wasp Version
-
-You can specify the version of Wasp to use for deployment by setting the `wasp-version` input. If this is not defined, Wasp will default to using the latest version.
-
-### Add the Action to your repo
-
-Create a file called `deploy.yml` in `.github/workflows` folder in your repo with this content:
-
+<!-- TODO: Show example workflow for Fly.io deployment:
 ```yml
-name: Deploy to Fly
+name: Deploy to Fly.io
 
 on:
   push:
     branches:
       - "main"
+
 jobs:
   deploy:
     name: Deploy with Wasp
@@ -47,12 +30,66 @@ jobs:
     steps:
       - uses: wasp-lang/deploy-action@main
         with:
-          # Required: Fly.io API token
+          platform: fly
           fly-token: ${{ secrets.FLY_TOKEN }}
-          # Optional: Override the default Fly server URL with a custom domain
-          server-url: ${{ secrets.SERVER_URL }}
-          # Optional: Set the Wasp version to use, defaults to latest
-          wasp-version: "0.16.0"
+          server-url: ${{ secrets.SERVER_URL }}  # Optional
+          wasp-version: "0.16.0"                 # Optional
 ```
+-->
 
-Notice that we are using the `secrets.FLY_TOKEN` so Wasp knows how to deploy.
+## Deploying to Railway
+
+<!-- TODO: Explain Railway setup:
+- Prerequisites: Run `wasp deploy railway launch <project-name>` locally first
+- No configuration files to commit (Railway stores config on platform)
+- Project name MUST be max 25 characters
+- Get Railway token from Project Settings → Tokens (project token recommended)
+- Add token as repository secret called RAILWAY_TOKEN
+- Optional: Workspace ID for multi-workspace accounts
+- Link to GitHub docs on creating secrets
+-->
+
+<!-- TODO: Show example workflow for Railway deployment:
+```yml
+name: Deploy to Railway
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  deploy:
+    name: Deploy with Wasp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasp-lang/deploy-action@main
+        with:
+          platform: railway
+          railway-token: ${{ secrets.RAILWAY_TOKEN }}
+          project-name: my-app                       # Required (max 25 chars)
+          railway-workspace: ${{ secrets.RAILWAY_WORKSPACE }}  # Optional
+          server-url: ${{ secrets.SERVER_URL }}      # Optional
+          wasp-version: "0.16.0"                     # Optional
+```
+-->
+
+## Action Inputs
+
+<!-- TODO: Document all inputs:
+- platform (required): 'fly' or 'railway'
+- fly-token (required for fly): Fly.io API token
+- railway-token (required for railway): Railway API token
+- project-name (required for railway): Project name, max 25 characters
+- railway-workspace (optional): Railway workspace ID for multi-workspace accounts
+- server-url (optional): Custom server URL for the React app
+- wasp-version (optional): Specific Wasp version to use, defaults to latest
+-->
+
+## Breaking Changes
+
+<!-- TODO: Add breaking change notice:
+- Existing users MUST add `platform: fly` to their workflow to continue working
+- The `fly-token` input is no longer required by default (only when platform is 'fly')
+- Show before/after example
+-->

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For detailed instructions on setting up repository secrets, visit: [GitHub Docs:
 
 - Prerequisites: Run `wasp deploy fly launch <basename> <region>` locally first
 - Commit the generated `fly-server.toml` and `fly-client.toml` files to repository
-- Get Fly.io API token from https://fly.io/user/personal_access_tokens
-- Add token as repository secret called `FLY_TOKEN`
+- Add Github secrets:
+  - [Get Fly.io API token](https://fly.io/user/personal_access_tokens) and add it as repository secret called `FLY_TOKEN`
 
 ### Example
 
@@ -58,14 +58,12 @@ jobs:
 
 ## Deploying to Railway
 
-- Prerequisites: Run `wasp deploy railway launch <project-name>` locally first
-- No configuration files to commit (Railway stores config on platform)
-- Project name MUST be max 25 characters
-- Get a Railway **project token**
-- Add token as repository secret called `RAILWAY_TOKEN`
-- Add Railway workspace ID as repository secret called `RAILWAY_WORKSPACE_ID` (optional, needed for multi-workspace accounts)
+### Requirements
 
-### Getting the Railway Token
+- Prerequisites: Run `wasp deploy railway launch <project-name>` locally first
+- Add Github secrets as below:
+  - Get a Railway **project token** and add it as repository secret called `RAILWAY_TOKEN`
+  - Add Railway workspace ID as repository secret called `RAILWAY_WORKSPACE_ID` (optional, needed for multi-workspace accounts)
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Read more on each platform in our [docs](https://wasp.sh/docs/deployment/deploym
 ### General
 
 - `platform` (required): 'fly' or 'railway'
+- `node-version` (optional): Node.js version to use, defaults to '22'
 - `server-url` (optional): If you have configured a custom domain for your server, provide its URL here. If this is not defined, Wasp will default to using the deployment URL provided by the platform.
 - `wasp-version` (optional): Specific Wasp version to use, defaults to latest
 
@@ -52,6 +53,7 @@ jobs:
         with:
           platform: fly
           fly-token: ${{ secrets.FLY_TOKEN }}
+          node-version: "22" # Optional, defaults to 22
           server-url: ${{ secrets.SERVER_URL }} # Optional
           wasp-version: "0.18.0" # Optional
 ```

--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,11 @@ inputs:
   project-name:
     description: "Project/app name (required for Railway, max 25 characters)"
     required: false
-  railway-workspace:
+  railway-workspace-id:
     description: "Railway workspace ID (optional, for multi-workspace accounts)"
     required: false
   server-url:
-    description: "Server URL for the React app"
+    description: "Server URL used by the React app"
     required: false
   wasp-version:
     description: "Version of Wasp to use for deployment"
@@ -66,7 +66,7 @@ runs:
       run: |
         # For Railway accounts with multiple workspaces, specify which one to use
         WORKSPACE_ARG=""
-        RAILWAY_WORKSPACE="${{ inputs.railway-workspace }}"
+        RAILWAY_WORKSPACE="${{ inputs.railway-workspace-id }}"
         if [ -n "$RAILWAY_WORKSPACE" ]; then
           WORKSPACE_ARG="--workspace $RAILWAY_WORKSPACE"
         fi

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,6 @@ inputs:
   project-name:
     description: "Project/app name (required for Railway, max 25 characters)"
     required: false
-  railway-workspace-id:
-    description: "Railway workspace ID (optional, for multi-workspace accounts)"
-    required: false
   server-url:
     description: "Server URL used by the React app"
     required: false
@@ -73,16 +70,6 @@ runs:
     - name: Deploy to Railway
       if: ${{ inputs.platform == 'railway' }}
       shell: bash
-      run: |
-        PROJECT_NAME="${{ inputs.project-name }}"
-
-        # For Railway accounts with multiple workspaces, specify which one to use
-        WORKSPACE_ARG=""
-        if [ -n "${{ inputs.railway-workspace-id }}" ]; then
-          WORKSPACE_ARG="--workspace ${{ inputs.railway-workspace-id }}"
-        fi
-
-        # Note: WORKSPACE_ARG is intentionally unquoted to allow optional flag expansion
-        wasp deploy railway deploy "$PROJECT_NAME" $WORKSPACE_ARG
+      run: wasp deploy railway deploy "${{ inputs.project-name }}"
       env:
         RAILWAY_API_TOKEN: ${{ inputs.railway-token }}

--- a/action.yml
+++ b/action.yml
@@ -72,4 +72,4 @@ runs:
       shell: bash
       run: wasp deploy railway deploy "${{ inputs.project-name }}"
       env:
-        RAILWAY_API_TOKEN: ${{ inputs.railway-token }}
+        RAILWAY_TOKEN: ${{ inputs.railway-token }}

--- a/action.yml
+++ b/action.yml
@@ -72,4 +72,4 @@ runs:
       shell: bash
       run: wasp deploy railway deploy "${{ inputs.project-name }}"
       env:
-        RAILWAY_TOKEN: ${{ inputs.railway-token }}
+        RAILWAY_API_TOKEN: ${{ inputs.railway-token }}

--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,19 @@ inputs:
   wasp-version:
     description: "Version of Wasp to use for deployment"
     required: false
+  node-version:
+    description: "Node.js version to use"
+    required: false
+    default: "22"
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
 
     - name: Install Wasp
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,21 @@
 name: "Wasp Deploy"
-description: "Deploy with Wasp to Fly.io"
+description: "Deploy with Wasp to Fly.io or Railway"
 inputs:
-  fly-token:
-    description: "Fly.io API token"
+  platform:
+    description: "Deployment platform: 'fly' or 'railway'"
     required: true
+  fly-token:
+    description: "Fly.io API token (required when platform is 'fly')"
+    required: false
+  railway-token:
+    description: "Railway API token (required when platform is 'railway')"
+    required: false
+  project-name:
+    description: "Project/app name (required for Railway, max 25 characters)"
+    required: false
+  railway-workspace:
+    description: "Railway workspace ID (optional, for multi-workspace accounts)"
+    required: false
   server-url:
     description: "Server URL for the React app"
     required: false
@@ -14,6 +26,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
+
     - name: Install Wasp
       shell: bash
       run: |
@@ -24,14 +37,48 @@ runs:
         curl -sSL https://get.wasp.sh/installer.sh | sh -s -- $VERSION_PARAM
 
     - name: Install Flyctl
+      if: ${{ inputs.platform == 'fly' }}
       uses: superfly/flyctl-actions/setup-flyctl@master
-    - name: Deploy
+
+    - name: Install Railway CLI
+      if: ${{ inputs.platform == 'railway' }}
+      shell: bash
       run: |
-        if [ -n "${{ inputs.server-url }}" ]; then
-          REACT_APP_API_URL=${{ inputs.server-url }} wasp deploy fly deploy
+        npm install -g @railway/cli
+        railway --version
+
+    - name: Deploy to Fly.io
+      if: ${{ inputs.platform == 'fly' }}
+      shell: bash
+      run: |
+        SERVER_URL="${{ inputs.server-url }}"
+        if [ -n "$SERVER_URL" ]; then
+          REACT_APP_API_URL="$SERVER_URL" wasp deploy fly deploy
         else
           wasp deploy fly deploy
         fi
-      shell: bash
       env:
         FLY_API_TOKEN: ${{ inputs.fly-token }}
+
+    - name: Deploy to Railway
+      if: ${{ inputs.platform == 'railway' }}
+      shell: bash
+      run: |
+        # For Railway accounts with multiple workspaces, specify which one to use
+        WORKSPACE_ARG=""
+        RAILWAY_WORKSPACE="${{ inputs.railway-workspace }}"
+        if [ -n "$RAILWAY_WORKSPACE" ]; then
+          WORKSPACE_ARG="--workspace $RAILWAY_WORKSPACE"
+        fi
+
+        SERVER_URL="${{ inputs.server-url }}"
+        PROJECT_NAME="${{ inputs.project-name }}"
+
+        # Note: WORKSPACE_ARG is intentionally unquoted to allow optional flag expansion
+        if [ -n "$SERVER_URL" ]; then
+          REACT_APP_API_URL="$SERVER_URL" wasp deploy railway deploy "$PROJECT_NAME" $WORKSPACE_ARG
+        else
+          wasp deploy railway deploy "$PROJECT_NAME" $WORKSPACE_ARG
+        fi
+      env:
+        RAILWAY_API_TOKEN: ${{ inputs.railway-token }}

--- a/action.yml
+++ b/action.yml
@@ -47,16 +47,17 @@ runs:
         npm install -g @railway/cli
         railway --version
 
+    - name: Set custom server URL if provided
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.server-url }}" ]; then
+          echo "REACT_APP_API_URL=${{ inputs.server-url }}" >> $GITHUB_ENV
+        fi
+
     - name: Deploy to Fly.io
       if: ${{ inputs.platform == 'fly' }}
       shell: bash
-      run: |
-        SERVER_URL="${{ inputs.server-url }}"
-        if [ -n "$SERVER_URL" ]; then
-          REACT_APP_API_URL="$SERVER_URL" wasp deploy fly deploy
-        else
-          wasp deploy fly deploy
-        fi
+      run: wasp deploy fly deploy
       env:
         FLY_API_TOKEN: ${{ inputs.fly-token }}
 
@@ -64,21 +65,15 @@ runs:
       if: ${{ inputs.platform == 'railway' }}
       shell: bash
       run: |
-        # For Railway accounts with multiple workspaces, specify which one to use
-        WORKSPACE_ARG=""
-        RAILWAY_WORKSPACE="${{ inputs.railway-workspace-id }}"
-        if [ -n "$RAILWAY_WORKSPACE" ]; then
-          WORKSPACE_ARG="--workspace $RAILWAY_WORKSPACE"
-        fi
-
-        SERVER_URL="${{ inputs.server-url }}"
         PROJECT_NAME="${{ inputs.project-name }}"
 
-        # Note: WORKSPACE_ARG is intentionally unquoted to allow optional flag expansion
-        if [ -n "$SERVER_URL" ]; then
-          REACT_APP_API_URL="$SERVER_URL" wasp deploy railway deploy "$PROJECT_NAME" $WORKSPACE_ARG
-        else
-          wasp deploy railway deploy "$PROJECT_NAME" $WORKSPACE_ARG
+        # For Railway accounts with multiple workspaces, specify which one to use
+        WORKSPACE_ARG=""
+        if [ -n "${{ inputs.railway-workspace-id }}" ]; then
+          WORKSPACE_ARG="--workspace ${{ inputs.railway-workspace-id }}"
         fi
+
+        # Note: WORKSPACE_ARG is intentionally unquoted to allow optional flag expansion
+        wasp deploy railway deploy "$PROJECT_NAME" $WORKSPACE_ARG
       env:
         RAILWAY_API_TOKEN: ${{ inputs.railway-token }}


### PR DESCRIPTION
Adds Railway as a deployment platform option alongside existing Fly.io support. Users can now choose between platforms using the `platform` input.

## Changes

### Core Functionality
- ✅ Add `platform` input (required): Choose `'fly'` or `'railway'`
- ✅ Add Railway-specific inputs: `railway-token`, `project-name`, `railway-workspace`
- ✅ Conditional CLI installation (Flyctl for Fly, Railway CLI for Railway)
- ✅ Conditional deployment logic for both platforms
- ✅ Improved bash variable handling

### Documentation
- 📝 README updated with TODO comments for final documentation
- 📝 Sections planned for: Fly setup, Railway setup, platform comparison, breaking changes

## Example Usage

### Fly.io (existing users must add `platform: fly`)
```yaml
- uses: wasp-lang/deploy-action@main
  with:
    platform: fly
    fly-token: ${{ secrets.FLY_TOKEN }}
```

### Railway (new)
```yaml
- uses: wasp-lang/deploy-action@main
  with:
    platform: railway
    railway-token: ${{ secrets.RAILWAY_TOKEN }}
    project-name: my-app
```

## Breaking Changes

⚠️ **Existing users must update their workflows to add `platform: fly`**

## TODO 

- [x] Complete README documentation (replace TODO comments with actual content)
- [ ] Test with real Fly.io deployment
- [ ] Test with real Railway deployment